### PR TITLE
Refactor `postOp()` to force-transfer funds and revert when called twice.

### DIFF
--- a/src/MagicSpend.sol
+++ b/src/MagicSpend.sol
@@ -78,8 +78,8 @@ contract MagicSpend is Ownable, IPaymaster {
     /// @notice Thrown in when `postOp()` is called a second time with `PostOpMode.postOpReverted`.
     ///
     /// @dev This should only really occur if for unknown reasons the transfer of the withdrwable
-    ///      funds to the user account failed (i.e., the paymaster balance is insufficient or, the
-    ///      user account refused the funds or ran out of gas on receive).
+    ///      funds to the user account failed (i.e. this contract's ETH balance is insufficient or
+    ///      the user account refused the funds or ran out of gas on receive).
     error UnexpectedPostOpRevertedMode();
 
     /// @dev Requires that the caller is the EntryPoint.

--- a/src/MagicSpend.sol
+++ b/src/MagicSpend.sol
@@ -75,6 +75,13 @@ contract MagicSpend is Ownable, IPaymaster {
     /// @notice Thrown when trying to withdraw funds but nothing is available.
     error NoExcess();
 
+    /// @notice Thrown in when `postOp()` is called a second time with `PostOpMode.postOpReverted`.
+    ///
+    /// @dev This should only really occur if for unknown reasons the transfer of the withdrwable
+    ///      funds to the user account failed (i.e., the paymaster balance is insufficient or, the
+    ///      user account refused the funds or ran out of gas on receive).
+    error UnexpectedPostOpRevertedMode();
+
     /// @dev Requires that the caller is the EntryPoint.
     modifier onlyEntryPoint() virtual {
         if (msg.sender != entryPoint()) revert Unauthorized();
@@ -123,21 +130,20 @@ contract MagicSpend is Ownable, IPaymaster {
         external
         onlyEntryPoint
     {
-        (uint256 withheld, address account) = abi.decode(context, (uint256, address));
-
+        // If `postOp` is called back after a first fail then revert entire `UserOperation`.
         if (mode == IPaymaster.PostOpMode.postOpReverted) {
-            // we failed to payout the excess, save it so the user can call withdrawGasExcess later
-            withdrawableFunds[account] += (withheld - actualGasCost);
-            return;
+            revert UnexpectedPostOpRevertedMode();
         }
 
-        // credit user difference between actual and withheld
+        (uint256 maxCost, address account) = abi.decode(context, (uint256, address));
+
+        // credit user difference between actual and maxCost
         // and unwithdrawn excess
-        uint256 excess = withdrawableFunds[account] + (withheld - actualGasCost);
+        uint256 withdrawable = withdrawableFunds[account] + (maxCost - actualGasCost);
         delete withdrawableFunds[account];
 
-        if (excess > 0) {
-            _withdraw(address(0), account, excess);
+        if (withdrawable > 0) {
+            SafeTransferLib.forceSafeTransferETH(account, withdrawable, SafeTransferLib.GAS_STIPEND_NO_STORAGE_WRITES);
         }
     }
 


### PR DESCRIPTION
This PR brings the following changes in `postOp()`:

1. If `postOp()` is called back (by the EntryPoint) with `IPaymaster.PostOpMode.postOpReverted`, we assume something unexpected happened and revert the `UserOperation`.
2. Available funds left after the `UserOperation` execution are force-transferred to the user account.
3. The gas associated with the transfer in (2) is capped to `SafeTransferLib.GAS_STIPEND_NO_STORAGE_WRITES` (2300), to mitigate the risk of a user account consuming all remaining gas in its `receive()` / `fallback()` function while not being charged for it by MagicSpend.

This implementation assumes:

1. MagicSpend will have enough ETH in its balance to pay for the withdrawal request amount in its totality (including the user operation execution gas cost).
2. The user account is not expected to perform any writes/expensive operations in its `receive()` / `fallback()` functions.