### PR TITLE
fix: keep track of pending withdrawals

### DIFF
--- a/src/MagicSpend.sol
+++ b/src/MagicSpend.sol
@@ -160,7 +160,9 @@ contract MagicSpend is Ownable, IPaymaster {
         // `PostOpMode.postOpReverted` should be impossible.
         // Only possible cause would be if this contract does not own enough ETH to transfer
         // but this is checked at the validation step.
-        assert(mode != PostOpMode.postOpReverted);
+        if (mode == PostOpMode.postOpReverted) {
+            revert UnexpectedPostOpRevertedMode();
+        }
 
         (uint256 maxGasCost, address account) = abi.decode(context, (uint256, address));
 

--- a/src/MagicSpend.sol
+++ b/src/MagicSpend.sol
@@ -147,7 +147,10 @@ contract MagicSpend is Ownable, IPaymaster {
 
         // NOTE: Do not include the gas part in withdrawable funds because it is considered already consumed at this point.
         //      `postOp()` will refund the amout of gas that was not consumed.
-        _withdrawableETH[userOp.sender] += withdrawAmount - maxCost;
+        uint256 nonGasAmount = withdrawAmount - maxCost;
+        if (nonGasAmount > 0) {
+            _withdrawableETH[userOp.sender] += nonGasAmount;
+        }
         context = abi.encode(maxCost, userOp.sender);
     }
 

--- a/src/MagicSpend.sol
+++ b/src/MagicSpend.sol
@@ -128,20 +128,19 @@ contract MagicSpend is Ownable, IPaymaster {
             revert UnsupportedPaymasterAsset(withdrawRequest.asset);
         }
 
-        _validateRequest(userOp.sender, withdrawRequest);
-
-        bool sigFailed = !isValidWithdrawSignature(userOp.sender, withdrawRequest);
-        validationData = (sigFailed ? 1 : 0) | (uint256(withdrawRequest.expiry) << 160);
-
         // Ensure at validation that the contract has enough balance to cover the requested funds.
         // NOTE: This check is necessary to enforce that the contract will be able to transfer the remaining funds
         //       when `postOp()` is called back after the `UserOperation` has been executed.
         uint256 newPendingWithdrawals = _pendingWithdrawals + withdrawAmount;
-
         if ((newPendingWithdrawals - 1) > address(this).balance) {
             uint256 availableBalance = address(this).balance - (_pendingWithdrawals - 1);
             revert InsufficientAvailableBalance(withdrawAmount, availableBalance);
         }
+
+        _validateRequest(userOp.sender, withdrawRequest);
+
+        bool sigFailed = !isValidWithdrawSignature(userOp.sender, withdrawRequest);
+        validationData = (sigFailed ? 1 : 0) | (uint256(withdrawRequest.expiry) << 160);
 
         // Register the new pending withdrawals.
         _pendingWithdrawals = newPendingWithdrawals;

--- a/test/PostOp.t.sol
+++ b/test/PostOp.t.sol
@@ -11,29 +11,39 @@ contract PostOpTest is PaymasterMagicSpendBaseTest {
 
     function test_transfersExcess(uint256 mode, uint256 amount_, uint256 maxCost_, uint256 actualCost) public {
         mode = bound(mode, 0, 1);
+        amount_ = bound(amount_, 0, type(uint256).max - 1);
         maxCost_ = bound(maxCost_, 0, amount_);
         actualCost = bound(actualCost, 0, maxCost_);
+
+        maxCost = maxCost_;
         amount = amount_;
 
         assertEq(withdrawer.balance, 0);
         vm.deal(address(magic), amount);
         (bytes memory context,) = magic.validatePaymasterUserOp(_getUserOp(), userOpHash, maxCost_);
-        uint256 expectedBalance = amount - actualCost;
+
         magic.postOp(IPaymaster.PostOpMode(mode), context, actualCost);
+
+        uint256 expectedBalance = amount - actualCost;
         assertEq(withdrawer.balance, expectedBalance);
     }
 
     function test_RevertsIfPostOpFailed(uint256 amount_, uint256 maxCost_, uint256 actualCost) public {
+        amount_ = bound(amount_, 0, type(uint256).max - 1);
         maxCost_ = bound(maxCost_, 0, amount_);
         actualCost = bound(actualCost, 0, maxCost_);
+
         amount = amount_;
 
         assertEq(withdrawer.balance, 0);
         vm.deal(address(magic), amount);
+
         (bytes memory context,) = magic.validatePaymasterUserOp(_getUserOp(), userOpHash, maxCost_);
-        uint256 expectedBalance = 0;
+
         vm.expectRevert();
         magic.postOp(IPaymaster.PostOpMode.postOpReverted, context, actualCost);
+
+        uint256 expectedBalance = 0;
         assertEq(withdrawer.balance, expectedBalance);
     }
 }

--- a/test/PostOp.t.sol
+++ b/test/PostOp.t.sol
@@ -40,7 +40,7 @@ contract PostOpTest is PaymasterMagicSpendBaseTest {
 
         (bytes memory context,) = magic.validatePaymasterUserOp(_getUserOp(), userOpHash, maxCost_);
 
-        vm.expectRevert();
+        vm.expectRevert(MagicSpend.UnexpectedPostOpRevertedMode.selector);
         magic.postOp(IPaymaster.PostOpMode.postOpReverted, context, actualCost);
 
         uint256 expectedBalance = 0;

--- a/test/Validate.t.sol
+++ b/test/Validate.t.sol
@@ -18,10 +18,12 @@ abstract contract ValidateTest is MagicSpendTest {
         // avoid precompiles
         vm.assume(withdrawer_ > address(0x10000));
         vm.assume(withdrawer_ != address(vm));
+
         asset = address(0);
         withdrawer = withdrawer_;
         amount = amount_;
         nonce = nonce_;
+
         vm.deal(address(magic), amount);
         vm.expectEmit(true, true, true, true);
         emit MagicSpend.MagicSpendWithdrawal(withdrawer, asset, amount, nonce);

--- a/test/WithdrawGasExcess.t.sol
+++ b/test/WithdrawGasExcess.t.sol
@@ -10,9 +10,12 @@ contract WithdrawGasExcess is PaymasterMagicSpendBaseTest {
     }
 
     function test_transferExcess(uint256 amount_, uint256 maxCost_, uint256 actual) public {
-        vm.assume(maxCost_ < amount_);
-        vm.assume(actual <= maxCost_);
+        maxCost_ = bound(maxCost_, 0, type(uint256).max - 2);
+        actual = bound(actual, 0, maxCost_);
+        amount_ = bound(amount_, maxCost_ + 1, type(uint256).max - 1);
+
         amount = amount_;
+
         vm.deal(address(magic), amount);
         magic.validatePaymasterUserOp(_getUserOp(), userOpHash, maxCost_);
 
@@ -24,7 +27,9 @@ contract WithdrawGasExcess is PaymasterMagicSpendBaseTest {
     }
 
     function test_RevertsIfNoExcess(uint256 maxCost_) public {
+        maxCost_ = bound(maxCost_, 0, type(uint256).max - 1);
         amount = maxCost_;
+
         vm.deal(address(magic), amount);
         magic.validatePaymasterUserOp(_getUserOp(), userOpHash, maxCost_);
 


### PR DESCRIPTION
This PR fixes https://github.com/code-423n4/2024-03-coinbase-findings/issues/110.

Implementation changes:

1. Adds a `_pendingWithdrawals` state variable whose initial value is set to 1 (for gas)
2. In `validatePaymasterUserOp()`:
 - revert if the withdraw amount is above the available balance (`available balance = balance - _pendingWithdrawals`).
 - increment `_pendingWithdrawals`
3. In `postOp()` reset `_pendingWithdrawals` to 1 if needed
4. Revert with `UnexpectedPostOpRevertedMode` in `postOp()` instead of asserting.

Tests changes:
Minor refactoring, the biggest changes being in `test_revertsInsufficientAvailableBalance()` to add fuzzing.
