### PR TITLE
[WIP] An immutable rebalancing approach for magic spend

### DIFF
--- a/test/OwnerWithdraw.t.sol
+++ b/test/OwnerWithdraw.t.sol
@@ -1,36 +1,36 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.8.21;
+// // SPDX-License-Identifier: MIT
+// pragma solidity >=0.8.21;
 
-import {Ownable} from "./MagicSpend.t.sol";
-import {MagicSpendTest} from "./MagicSpend.t.sol";
-import {MockERC20} from "solady/test/utils/mocks/MockERC20.sol";
+// import {Ownable} from "./MagicSpend.t.sol";
+// import {MagicSpendTest} from "./MagicSpend.t.sol";
+// import {MockERC20} from "solady/test/utils/mocks/MockERC20.sol";
 
-contract OwnerWithdrawTest is MagicSpendTest {
-    MockERC20 token = new MockERC20("test", "TEST", 18);
+// contract OwnerWithdrawTest is MagicSpendTest {
+//     MockERC20 token = new MockERC20("test", "TEST", 18);
 
-    function test_revertsIfNotOwner() public {
-        vm.startPrank(withdrawer);
-        vm.expectRevert(Ownable.Unauthorized.selector);
-        magic.ownerWithdraw(address(token), withdrawer, 1);
-    }
+//     function test_revertsIfNotOwner() public {
+//         vm.startPrank(withdrawer);
+//         vm.expectRevert(Ownable.Unauthorized.selector);
+//         magic.ownerWithdraw(address(token), withdrawer, 1);
+//     }
 
-    function test_transfersERC20Successfully(uint256 amount_) public {
-        vm.startPrank(owner);
-        amount = amount_;
-        token.mint(address(magic), amount);
-        asset = address(token);
-        assertEq(token.balanceOf(owner), 0);
-        magic.ownerWithdraw(asset, owner, amount);
-        assertEq(token.balanceOf(owner), amount);
-    }
+//     function test_transfersERC20Successfully(uint256 amount_) public {
+//         vm.startPrank(owner);
+//         amount = amount_;
+//         token.mint(address(magic), amount);
+//         asset = address(token);
+//         assertEq(token.balanceOf(owner), 0);
+//         magic.ownerWithdraw(asset, owner, amount);
+//         assertEq(token.balanceOf(owner), amount);
+//     }
 
-    function test_transfersETHSuccessfully(uint256 amount_) public {
-        vm.deal(address(magic), amount_);
-        vm.startPrank(owner);
-        amount = amount_;
-        asset = address(0);
-        assertEq(owner.balance, 0);
-        magic.ownerWithdraw(asset, owner, amount);
-        assertEq(owner.balance, amount);
-    }
-}
+//     function test_transfersETHSuccessfully(uint256 amount_) public {
+//         vm.deal(address(magic), amount_);
+//         vm.startPrank(owner);
+//         amount = amount_;
+//         asset = address(0);
+//         assertEq(owner.balance, 0);
+//         magic.ownerWithdraw(asset, owner, amount);
+//         assertEq(owner.balance, amount);
+//     }
+// }

--- a/test/OwnerWithdraw.t.sol
+++ b/test/OwnerWithdraw.t.sol
@@ -1,36 +1,36 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity >=0.8.21;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
 
-// import {Ownable} from "./MagicSpend.t.sol";
-// import {MagicSpendTest} from "./MagicSpend.t.sol";
-// import {MockERC20} from "solady/test/utils/mocks/MockERC20.sol";
+import {Ownable} from "./MagicSpend.t.sol";
+import {MagicSpendTest} from "./MagicSpend.t.sol";
+import {MockERC20} from "solady/test/utils/mocks/MockERC20.sol";
 
-// contract OwnerWithdrawTest is MagicSpendTest {
-//     MockERC20 token = new MockERC20("test", "TEST", 18);
+contract OwnerWithdrawTest is MagicSpendTest {
+    MockERC20 token = new MockERC20("test", "TEST", 18);
 
-//     function test_revertsIfNotOwner() public {
-//         vm.startPrank(withdrawer);
-//         vm.expectRevert(Ownable.Unauthorized.selector);
-//         magic.ownerWithdraw(address(token), withdrawer, 1);
-//     }
+    function test_revertsIfNotOwner() public {
+        vm.startPrank(withdrawer);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        magic.ownerWithdraw(address(token), withdrawer, 1);
+    }
 
-//     function test_transfersERC20Successfully(uint256 amount_) public {
-//         vm.startPrank(owner);
-//         amount = amount_;
-//         token.mint(address(magic), amount);
-//         asset = address(token);
-//         assertEq(token.balanceOf(owner), 0);
-//         magic.ownerWithdraw(asset, owner, amount);
-//         assertEq(token.balanceOf(owner), amount);
-//     }
+    function test_transfersERC20Successfully(uint256 amount_) public {
+        vm.startPrank(owner);
+        amount = amount_;
+        token.mint(address(magic), amount);
+        asset = address(token);
+        assertEq(token.balanceOf(owner), 0);
+        magic.ownerWithdraw(asset, owner, amount);
+        assertEq(token.balanceOf(owner), amount);
+    }
 
-//     function test_transfersETHSuccessfully(uint256 amount_) public {
-//         vm.deal(address(magic), amount_);
-//         vm.startPrank(owner);
-//         amount = amount_;
-//         asset = address(0);
-//         assertEq(owner.balance, 0);
-//         magic.ownerWithdraw(asset, owner, amount);
-//         assertEq(owner.balance, amount);
-//     }
-// }
+    function test_transfersETHSuccessfully(uint256 amount_) public {
+        vm.deal(address(magic), amount_);
+        vm.startPrank(owner);
+        amount = amount_;
+        asset = address(0);
+        assertEq(owner.balance, 0);
+        magic.ownerWithdraw(asset, owner, amount);
+        assertEq(owner.balance, amount);
+    }
+}


### PR DESCRIPTION
Context: #22

(RFC I'm not confident if even this is the right approach with regards to https://eips.ethereum.org/EIPS/eip-7562)

Highlights:
- [x] Removes `Ownable` in favor of an immutable paymaster contract
- [ ] Adds `Credits` mapping(s) for both ETH and ERC20 keeping track of creditors' fund
- [ ] An optional `RebalanceOperation`(s) for moving the credited funds between inside `validatePaymasterUserOp`